### PR TITLE
Remove outdated "org.testcontainers:docker-compose:0.9.9" dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,7 @@
 
     <!-- Test -->
     <junit.version>4.12</junit.version>
-    <testcontainers.version>1.5.1</testcontainers.version>
-    <testcontainers.docker-compose.version>0.9.9</testcontainers.docker-compose.version>
+    <testcontainers.version>1.7.1</testcontainers.version>
   </properties>
 
   <build>

--- a/spring-data-chaincode/pom.xml
+++ b/spring-data-chaincode/pom.xml
@@ -98,12 +98,6 @@
 			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.testcontainers</groupId>
-			<artifactId>docker-compose</artifactId>
-			<version>${testcontainers.docker-compose.version}</version>
-			<scope>test</scope>
-		</dependency>
 
 	</dependencies>
   <build>


### PR DESCRIPTION
Hi! I see you're using `org.testcontainers:docker-compose:0.9.9` dependency, but it is outdated and Docker Compose functionality was merged into core of Testcontainers long time ago.

And since I was touching the code, I also updated to the latest version of Testcontainers. You might want to take a look at it (release 1.7.0) because we improved Docker Compose support a lot (including Wait strategies, log following, etc)

Happy testing with Testcontainers 🙂 