### PR TITLE
Use fabric-sdk-java 1.3.0 instead of 1.3.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <hibernate.version>4.2.1.Final</hibernate.version>
 
     <!-- Fabric -->
-    <fabric-sdk.version>1.3.0-SNAPSHOT</fabric-sdk.version>
+    <fabric-sdk.version>1.3.0</fabric-sdk.version>
 
     <!-- Logging -->
     <logback.version>1.0.13</logback.version>


### PR DESCRIPTION
1.3.0-SNAPSHOT doesn't exist on
https://mvnrepository.com/artifact/org.hyperledger.fabric-sdk-java/fabric-sdk-java